### PR TITLE
Modify `mem_read()`

### DIFF
--- a/src/operations/ld.rs
+++ b/src/operations/ld.rs
@@ -11,7 +11,7 @@ pub fn handle_ld(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     vm.registers[dest_reg] = mem_read(
         vm.registers[Register::PC.usize()].wrapping_add(pc_offset),
         vm,
-    );
+    )?;
     update_flags(vm, vm.registers[dest_reg])?;
     Ok(())
 }

--- a/src/operations/ldi.rs
+++ b/src/operations/ldi.rs
@@ -11,7 +11,7 @@ pub fn handle_ldi(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     vm.registers[dest_reg] = mem_read(
         vm.registers[Register::PC.usize()].wrapping_add(pc_offset),
         vm,
-    );
+    )?;
     update_flags(vm, vm.registers[dest_reg])?;
     Ok(())
 }

--- a/src/operations/ldr.rs
+++ b/src/operations/ldr.rs
@@ -8,7 +8,7 @@ pub fn handle_ldr(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let dest_reg = ((instruction >> 9) & 0x7) as usize;
     let base_reg = ((instruction >> 6) & 0x7) as usize;
     let offset = sign_extend(instruction & 0x3F, 6);
-    vm.registers[dest_reg] = mem_read(vm.registers[base_reg].wrapping_add(offset), vm);
+    vm.registers[dest_reg] = mem_read(vm.registers[base_reg].wrapping_add(offset), vm)?;
     update_flags(vm, vm.registers[dest_reg])?;
     Ok(())
 }

--- a/src/operations/st.rs
+++ b/src/operations/st.rs
@@ -28,7 +28,10 @@ mod test {
         // ST   src_reg pc_offset
         // 0011 011     000001010
         let st_ix = 0x360A;
-        assert_eq!(mem_read(pc_content.wrapping_add(pc_offset), &mut vm).unwrap(), 0); // Memory Address is empty
+        assert_eq!(
+            mem_read(pc_content.wrapping_add(pc_offset), &mut vm).unwrap(),
+            0
+        ); // Memory Address is empty
         let res = handle_st(st_ix, &mut vm);
         assert!(res.is_ok());
         assert_eq!(

--- a/src/operations/st.rs
+++ b/src/operations/st.rs
@@ -28,11 +28,11 @@ mod test {
         // ST   src_reg pc_offset
         // 0011 011     000001010
         let st_ix = 0x360A;
-        assert_eq!(mem_read(pc_content.wrapping_add(pc_offset), &vm), 0); // Memory Address is empty
+        assert_eq!(mem_read(pc_content.wrapping_add(pc_offset), &mut vm).unwrap(), 0); // Memory Address is empty
         let res = handle_st(st_ix, &mut vm);
         assert!(res.is_ok());
         assert_eq!(
-            mem_read(pc_content.wrapping_add(pc_offset), &vm),
+            mem_read(pc_content.wrapping_add(pc_offset), &mut vm).unwrap(),
             random_content
         );
     }

--- a/src/operations/sti.rs
+++ b/src/operations/sti.rs
@@ -8,7 +8,7 @@ pub fn handle_sti(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let address = mem_read(
         vm.registers[Register::PC.usize()].wrapping_add(pc_offset),
         vm,
-    );
+    )?;
     mem_write(address, vm.registers[src_reg], vm);
     Ok(())
 }
@@ -33,14 +33,14 @@ mod test {
             random_content,
             &mut vm,
         );
-        assert_eq!(mem_read(random_content, &vm), 0); // The memory in this address should have no content yet.
+        assert_eq!(mem_read(random_content, &mut vm).unwrap(), 0); // The memory in this address should have no content yet.
 
         let res = handle_sti(sti_ix, &mut vm);
         assert!(res.is_ok());
         // The memory address 0x1234 should have the same content as R1
         assert_eq!(
-            mem_read(random_content, &vm),
-            mem_read(vm.registers[Register::R1.usize()], &vm)
+            mem_read(random_content, &mut vm).unwrap(),
+            mem_read(vm.registers[Register::R1.usize()], &mut vm).unwrap()
         );
     }
 }

--- a/src/operations/trap.rs
+++ b/src/operations/trap.rs
@@ -69,7 +69,7 @@ fn handle_out(vm: &mut VMState) -> Result<(), VMError> {
 
 fn handle_putsp(vm: &mut VMState) -> Result<(), VMError> {
     let mut memory_address = vm.registers[Register::R0.usize()];
-    let mut content = mem_read(memory_address, vm);
+    let mut content = mem_read(memory_address, vm)?;
     while content != 0 {
         let bytes: [u8; 2] = content.to_le_bytes();
         print_char(bytes[0]);
@@ -77,7 +77,7 @@ fn handle_putsp(vm: &mut VMState) -> Result<(), VMError> {
             print_char(bytes[1]);
         }
         memory_address = memory_address.wrapping_add(1);
-        content = mem_read(memory_address, vm);
+        content = mem_read(memory_address, vm)?;
     }
     Ok(())
 }
@@ -95,11 +95,11 @@ fn handle_in(vm: &mut VMState) -> Result<(), VMError> {
 
 fn handle_puts(vm: &mut VMState) -> Result<(), VMError> {
     let mut memory_address = vm.registers[Register::R0.usize()];
-    let mut content = mem_read(memory_address, vm);
+    let mut content = mem_read(memory_address, vm)?;
     while content != 0 {
         print_char(content.to_le_bytes()[0]);
         memory_address = memory_address.wrapping_add(1);
-        content = mem_read(memory_address, vm);
+        content = mem_read(memory_address, vm)?;
     }
     Ok(())
 }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -1,3 +1,5 @@
+use crate::error::VMError;
+
 #[allow(dead_code)]
 pub enum Register {
     R0 = 0,
@@ -14,6 +16,23 @@ pub enum Register {
 impl Register {
     pub const COUNT: usize = 10;
 
+    pub fn usize(self) -> usize {
+        self as usize
+    }
+}
+pub enum MemoryRegister {
+    Kbsr = 0xFE00, /* keyboard status */
+    Kbdr = 0xFE02, /* keyboard data */
+}
+
+impl TryInto<u16> for MemoryRegister {
+    type Error = VMError;
+    fn try_into(self) -> Result<u16, Self::Error> {
+        Ok(self as u16)
+    }
+}
+
+impl MemoryRegister {
     pub fn usize(self) -> usize {
         self as usize
     }


### PR DESCRIPTION
- Includes the handling of input when the address of memory to be read is the memory registry related to keyboard input. 
- Also includes necessary fixes to adapt to new changes:
     - params from: `(address: u16, vm: &VMState)`  to -> `(address: u16, vm: &mut VMState)`
     - return type from:  `void`  to -> `Result<u16, VMError>`