### PR TITLE
LDI opcode fix 

### DIFF
--- a/src/operations/ldi.rs
+++ b/src/operations/ldi.rs
@@ -8,10 +8,9 @@ use crate::{
 pub fn handle_ldi(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let dest_reg = ((instruction >> 9) & 0x7) as usize;
     let pc_offset = sign_extend(instruction & 0x1FF, 9);
-    vm.registers[dest_reg] = mem_read(
-        vm.registers[Register::PC.usize()].wrapping_add(pc_offset),
-        vm,
-    )?;
+    let first_addr = vm.registers[Register::PC.usize()].wrapping_add(pc_offset);
+    let final_addr = mem_read(first_addr, vm)?;
+    vm.registers[dest_reg] = mem_read(final_addr, vm)?;
     update_flags(vm, vm.registers[dest_reg])?;
     Ok(())
 }
@@ -19,19 +18,26 @@ pub fn handle_ldi(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{VMState, mem_write};
+    use crate::VMState;
 
     #[test]
     fn loads_register() {
         let mut vm = VMState::init().unwrap();
-        let pc_offset = 0x0007;
-        let pc_current_content = vm.registers[Register::PC.usize()];
-        mem_write(pc_current_content.wrapping_add(pc_offset), 1000, &mut vm);
+        let pc_content = 0x3000;
+        let pc_offset: u16 = 0x00FF;
+        let first_addr = pc_content + pc_offset;
+        let content_addr = 0x4000;
+        let random_content = 0x1234;
+        vm.memory[first_addr as usize] = content_addr;
+        vm.memory[content_addr as usize] = random_content;
+
+        assert_eq!(vm.registers[Register::PC.usize()], pc_content);
+        assert_eq!(vm.registers[Register::R1.usize()], 0); // Still has nothing
         // LDI  DestReg PCOffset
-        // 1010 001     000000111
-        let ldi_ix = 0xA207;
+        // 1010 001     011111111
+        let ldi_ix = 0xA2FF;
         let res = handle_ldi(ldi_ix, &mut vm);
         assert!(res.is_ok());
-        assert_eq!(vm.registers[Register::R1.usize()], 1000);
+        assert_eq!(vm.registers[Register::R1.usize()], random_content);
     }
 }


### PR DESCRIPTION
Previously I had misunderstood the LDI instruction and this PR fixes the mistake to the correct implementation. 
Previous implementation had the following steps: 
- Add offset to PC content, obtaining an address.
- Get memory[address] and place its content in destination register. 

Current implementation adds the missing step and does: 
- Add offset to PC content, obtaining the first address. 
- Get memory[first_address] and obtains a **second address**  _(Here previously missing step)_  
- Get memory[second_address] and place its content in destination register. 
