### PR TITLE
VM-User interaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,14 +6,8 @@ version = 4
 name = "basic-vm"
 version = "0.1.0"
 dependencies = [
- "termion",
+ "termios",
 ]
-
-[[package]]
-name = "bitflags"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "libc"
@@ -22,45 +16,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
+name = "termios"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
-name = "numtoa"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_termios"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
-
-[[package]]
-name = "termion"
-version = "4.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3669a69de26799d6321a5aa713f55f7e2cd37bd47be044b50f2acafc42c122bb"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
 dependencies = [
  "libc",
- "libredox",
- "numtoa",
- "redox_termios",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-termion = "4.0.5"
+termios = "0.3.3"

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,8 @@ build:
 clean:
 	cargo clean
 
-# For now until it takes CLI arguments
 run:
-	cargo run
+	cargo run -- $(path)
 
 doc:
 	cargo doc --open --no-deps

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,4 +7,5 @@ pub enum VMError {
     CouldNotReadFile(String),
     UnrecognizedOpcode,
     UnrecognizedTrapCode,
+    TermiosError(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 #[allow(dead_code)]
 #[derive(Debug)]
 pub enum VMError {
+    ErrorFlushinStdout(String),
+    WrongArgumentsLen,
     CouldNotReadChar(String),
     CouldNotReadFile(String),
     UnrecognizedOpcode,

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,9 @@ fn main() -> Result<(), VMError> {
             OpRES => println!("Opcode is RES"),
             OpRTI => println!("Opcode is RTI"),
         }
-        std::io::stdout().flush().map_err(|e| VMError::ErrorFlushinStdout(e.to_string()))?;
+        std::io::stdout()
+            .flush()
+            .map_err(|e| VMError::ErrorFlushinStdout(e.to_string()))?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
+use std::env;
 use std::fs::{self};
-use std::io::Read;
+use std::io::{Read, Write};
 
 use termion::raw::IntoRawMode;
 
@@ -49,13 +50,18 @@ impl VMState {
 }
 
 fn main() -> Result<(), VMError> {
+    let console_args: Vec<_> = env::args().collect();
+    if console_args.len() != 2 {
+        return Err(VMError::WrongArgumentsLen);
+    }
+    let path = console_args[1].clone();
     // Fill memory with instructions here
-    let example_file = read_file("./binary-examples/rogue.obj")?;
-    let mut _stdout = std::io::stdout().into_raw_mode().unwrap();
+    let file = read_file(&path)?;
+    let mut stdout = std::io::stdout().into_raw_mode().unwrap();
     // Initialize VM state
     let mut vm = VMState::init()?;
 
-    write_ixs_to_mem(example_file, &mut vm);
+    write_ixs_to_mem(file, &mut vm);
 
     let mut running = true;
 
@@ -83,6 +89,7 @@ fn main() -> Result<(), VMError> {
             OpRES => println!("Opcode is RES"),
             OpRTI => println!("Opcode is RTI"),
         }
+        stdout.flush().map_err(|e| VMError::ErrorFlushinStdout(e.to_string()))?; 
     }
 
     Ok(())

--- a/src/operations/trap.rs
+++ b/src/operations/trap.rs
@@ -17,7 +17,6 @@ pub fn handle_trap(instruction: u16, vm: &mut VMState, running: &mut bool) -> Re
     }
     Ok(())
 }
-
 enum TrapCode {
     Getc = 0x20,  /* get character from keyboard, not echoed onto the terminal */
     Out = 0x21,   /* output a character */
@@ -58,6 +57,7 @@ fn handle_getc(vm: &mut VMState) -> Result<(), VMError> {
         .map_err(|e| VMError::CouldNotReadChar(e.to_string()))?;
     vm.registers[Register::R0.usize()] = char[0] as u16;
     update_flags(vm, vm.registers[Register::R0.usize()])?;
+
     Ok(())
 }
 


### PR DESCRIPTION
- Change the use of `termion` lib for `termios` lib that allows the program to receive the `ctrl + c` signal. 
- Now the program disables input buffering (allowing a pressed key to be detected in the moment) and also allows for the user to quit with `ctrl + c`. 
- The VM now takes a path as CLI argument to find the binary file of the program to be executed. (Further documentation on this will be added to the README in a later PR.) 