### PR TITLE
VM restructure and refactor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,14 @@ use std::env;
 use std::io::Write;
 
 mod error;
-mod utils;
 mod flags;
 mod opcodes;
 mod operations;
 mod registers;
+mod utils;
 mod vm;
 
+use crate::error::VMError;
 use crate::opcodes::Opcode::{self, *};
 use crate::operations::add::handle_add;
 use crate::operations::and::handle_and;
@@ -27,7 +28,6 @@ use crate::operations::trap::handle_trap;
 use crate::registers::Register::*;
 use crate::utils::{disable_input_buffering, read_file};
 use crate::vm::VMState;
-use crate::error::VMError;
 
 fn main() -> Result<(), VMError> {
     let console_args: Vec<_> = env::args().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,14 @@
 use std::env;
-use std::fs::{self};
-use std::io::{Read, Write};
-use std::os::fd::AsRawFd;
-
-use termios::{ECHO, ICANON, TCSANOW, Termios, tcsetattr};
-
-use crate::error::VMError;
+use std::io::Write;
 
 mod error;
+mod utils;
+mod flags;
+mod opcodes;
+mod operations;
+mod registers;
+mod vm;
 
-use crate::flags::Flag;
 use crate::opcodes::Opcode::{self, *};
 use crate::operations::add::handle_add;
 use crate::operations::and::handle_and;
@@ -25,30 +24,10 @@ use crate::operations::st::handle_st;
 use crate::operations::sti::handle_sti;
 use crate::operations::str::handle_str;
 use crate::operations::trap::handle_trap;
-use crate::registers::MemoryRegister;
-use crate::registers::Register::{self, *};
-
-mod flags;
-mod opcodes;
-mod operations;
-mod registers;
-pub const MEMORY_MAX: usize = 1 << 16;
-
-pub struct VMState {
-    pub memory: [u16; MEMORY_MAX],
-    pub registers: [u16; Register::COUNT],
-}
-impl VMState {
-    pub fn init() -> Result<Self, VMError> {
-        let mut vm = Self {
-            memory: [0; MEMORY_MAX],
-            registers: [0; Register::COUNT],
-        };
-        vm.registers[Cond.usize()] = Flag::Zro.try_into()?;
-        vm.registers[PC.usize()] = 0x3000; // Set PC to starting position. 0x3000 is the default.
-        Ok(vm)
-    }
-}
+use crate::registers::Register::*;
+use crate::utils::{disable_input_buffering, read_file};
+use crate::vm::VMState;
+use crate::error::VMError;
 
 fn main() -> Result<(), VMError> {
     let console_args: Vec<_> = env::args().collect();
@@ -56,20 +35,19 @@ fn main() -> Result<(), VMError> {
         return Err(VMError::WrongArgumentsLen);
     }
     let path = console_args[1].clone();
-    // Fill memory with instructions here
     let file = read_file(&path)?;
 
     disable_input_buffering()?;
     // Initialize VM state
     let mut vm = VMState::init()?;
 
-    write_ixs_to_mem(file, &mut vm);
+    vm.write_ixs_to_mem(file);
 
     let mut running = true;
 
     while running {
         // Get the next instruction
-        let ix: u16 = mem_read(vm.registers[PC.usize()], &mut vm)?;
+        let ix: u16 = vm.mem_read(vm.registers[PC.usize()])?;
         vm.registers[PC.usize()] += 1;
         let opcode = Opcode::try_from(ix >> 12)?;
 
@@ -97,87 +75,4 @@ fn main() -> Result<(), VMError> {
     }
 
     Ok(())
-}
-
-fn disable_input_buffering() -> Result<(), VMError> {
-    let fd = std::io::stdin().lock().as_raw_fd();
-    let mut termios = Termios::from_fd(fd).map_err(|e| VMError::TermiosError(e.to_string()))?;
-    termios.c_lflag &= !ICANON & !ECHO;
-    tcsetattr(fd, TCSANOW, &termios).unwrap();
-    Ok(())
-}
-
-fn mem_read(address: u16, vm: &mut VMState) -> Result<u16, VMError> {
-    if address == MemoryRegister::Kbsr.try_into()? {
-        let char = get_char()?;
-        if char != 0 {
-            vm.memory[MemoryRegister::Kbsr.usize()] = 1 << 15;
-            vm.memory[MemoryRegister::Kbdr.usize()] = char;
-        } else {
-            vm.memory[MemoryRegister::Kbsr.usize()] = 0;
-        }
-    }
-    Ok(vm.memory[address as usize])
-}
-
-fn get_char() -> Result<u16, VMError> {
-    let mut buffer: [u8; 1] = [0];
-    std::io::stdin()
-        .read_exact(&mut buffer)
-        .map_err(|e| VMError::CouldNotReadChar(e.to_string()))?;
-    let char = buffer[0] as u16;
-
-    Ok(char)
-}
-
-fn mem_write(address: u16, val: u16, vm: &mut VMState) {
-    vm.memory[address as usize] = val;
-}
-
-fn read_file(path: &str) -> Result<Vec<u8>, VMError> {
-    let read_result = fs::read(path).map_err(|e| VMError::CouldNotReadFile(e.to_string()))?;
-    Ok(read_result)
-}
-
-fn write_ixs_to_mem(parsed_file: Vec<u8>, vm: &mut VMState) {
-    let mut file_index = 0;
-    let origin = u16::from_be_bytes([parsed_file[file_index], parsed_file[file_index + 1]]);
-    file_index += 2;
-
-    let mut offset = origin;
-    while file_index + 1 < parsed_file.len() {
-        // LC3 binaries come in big endian but we need to store it swapped
-        let content = u16::from_be_bytes([parsed_file[file_index], parsed_file[file_index + 1]]);
-        mem_write(offset, content, vm);
-        file_index += 2;
-        offset += 1;
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    #[test]
-    fn parse_file() {
-        let path = "./binary-examples/2048.obj";
-        let read_file = read_file(path).unwrap();
-        assert_eq!(read_file.len(), 2276);
-    }
-
-    #[test]
-    fn writes_ix_to_memory() {
-        let mut vm = VMState::init().unwrap();
-        let origin: u16 = 0x3000;
-        let first_ix: u16 = 0x4314;
-        let second_ix: u16 = 0x975A;
-        let binary = vec![
-            origin.to_be_bytes(),
-            first_ix.to_be_bytes(),
-            second_ix.to_be_bytes(),
-        ]
-        .concat();
-        write_ixs_to_mem(binary, &mut vm);
-        assert_eq!(vm.memory[origin as usize], first_ix);
-        assert_eq!(vm.memory[(origin + 1) as usize], second_ix);
-    }
 }

--- a/src/operations/ld.rs
+++ b/src/operations/ld.rs
@@ -1,24 +1,21 @@
 use crate::{
     VMState,
     error::VMError,
-    mem_read,
     operations::utils::{sign_extend, update_flags},
     registers::Register,
 };
 pub fn handle_ld(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let dest_reg = ((instruction >> 9) & 0x7) as usize;
     let pc_offset = sign_extend(instruction & 0x1FF, 9);
-    vm.registers[dest_reg] = mem_read(
-        vm.registers[Register::PC.usize()].wrapping_add(pc_offset),
-        vm,
-    )?;
+    vm.registers[dest_reg] =
+        vm.mem_read(vm.registers[Register::PC.usize()].wrapping_add(pc_offset))?;
     update_flags(vm, vm.registers[dest_reg])?;
     Ok(())
 }
 
 #[cfg(test)]
 mod test {
-    use crate::{VMState, mem_write, operations::ld::handle_ld, registers::Register};
+    use crate::{VMState, operations::ld::handle_ld, registers::Register};
 
     #[test]
     fn loads_a_register() {
@@ -26,7 +23,7 @@ mod test {
         let pc_value: u16 = 0x3000;
         let memory_address = pc_value.wrapping_add(offset_u16);
         let mut vm = VMState::init().unwrap();
-        mem_write(memory_address, 50, &mut vm);
+        vm.mem_write(memory_address, 50);
         // LD   DestReg PCOffset
         // 0010 001     000000100
         let ld_ix: u16 = 0x2204;

--- a/src/operations/ldi.rs
+++ b/src/operations/ldi.rs
@@ -1,7 +1,6 @@
 use crate::{
     VMState,
     error::VMError,
-    mem_read,
     operations::utils::{sign_extend, update_flags},
     registers::Register,
 };
@@ -9,8 +8,8 @@ pub fn handle_ldi(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let dest_reg = ((instruction >> 9) & 0x7) as usize;
     let pc_offset = sign_extend(instruction & 0x1FF, 9);
     let first_addr = vm.registers[Register::PC.usize()].wrapping_add(pc_offset);
-    let final_addr = mem_read(first_addr, vm)?;
-    vm.registers[dest_reg] = mem_read(final_addr, vm)?;
+    let final_addr = vm.mem_read(first_addr)?;
+    vm.registers[dest_reg] = vm.mem_read(final_addr)?;
     update_flags(vm, vm.registers[dest_reg])?;
     Ok(())
 }

--- a/src/operations/ldr.rs
+++ b/src/operations/ldr.rs
@@ -1,21 +1,20 @@
 use crate::{
     VMState,
     error::VMError,
-    mem_read,
     operations::utils::{sign_extend, update_flags},
 };
 pub fn handle_ldr(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let dest_reg = ((instruction >> 9) & 0x7) as usize;
     let base_reg = ((instruction >> 6) & 0x7) as usize;
     let offset = sign_extend(instruction & 0x3F, 6);
-    vm.registers[dest_reg] = mem_read(vm.registers[base_reg].wrapping_add(offset), vm)?;
+    vm.registers[dest_reg] = vm.mem_read(vm.registers[base_reg].wrapping_add(offset))?;
     update_flags(vm, vm.registers[dest_reg])?;
     Ok(())
 }
 
 #[cfg(test)]
 mod test {
-    use crate::{VMState, mem_write, operations::ldr::handle_ldr, registers::Register};
+    use crate::{VMState, operations::ldr::handle_ldr, registers::Register};
 
     #[test]
     fn loads_register() {
@@ -24,11 +23,7 @@ mod test {
         let offset: u16 = 0x0004; //offset that will be used in ix.
         let random_memory_content: u16 = 400;
         vm.registers[Register::R2.usize()] = content_base_reg;
-        mem_write(
-            content_base_reg.wrapping_add(offset),
-            random_memory_content,
-            &mut vm,
-        );
+        vm.mem_write(content_base_reg.wrapping_add(offset), random_memory_content);
         // LDR  DestReg BaseReg Offset
         // 0110 001     010     000100
         let ldr_ix = 0x6284;

--- a/src/operations/st.rs
+++ b/src/operations/st.rs
@@ -1,20 +1,17 @@
-use crate::{
-    VMState, error::VMError, mem_write, operations::utils::sign_extend, registers::Register,
-};
+use crate::{VMState, error::VMError, operations::utils::sign_extend, registers::Register};
 pub fn handle_st(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let src_reg = ((instruction >> 9) & 0x7) as usize;
     let pc_offset = sign_extend(instruction & 0x1FF, 9);
-    mem_write(
+    vm.mem_write(
         vm.registers[Register::PC.usize()].wrapping_add(pc_offset),
         vm.registers[src_reg],
-        vm,
     );
     Ok(())
 }
 
 #[cfg(test)]
 mod test {
-    use crate::{VMState, mem_read, operations::st::handle_st, registers::Register};
+    use crate::{VMState, operations::st::handle_st, registers::Register};
 
     #[test]
     fn stores_reg_value_in_memory() {
@@ -28,14 +25,11 @@ mod test {
         // ST   src_reg pc_offset
         // 0011 011     000001010
         let st_ix = 0x360A;
-        assert_eq!(
-            mem_read(pc_content.wrapping_add(pc_offset), &mut vm).unwrap(),
-            0
-        ); // Memory Address is empty
+        assert_eq!(vm.mem_read(pc_content.wrapping_add(pc_offset)).unwrap(), 0); // Memory Address is empty
         let res = handle_st(st_ix, &mut vm);
         assert!(res.is_ok());
         assert_eq!(
-            mem_read(pc_content.wrapping_add(pc_offset), &mut vm).unwrap(),
+            vm.mem_read(pc_content.wrapping_add(pc_offset)).unwrap(),
             random_content
         );
     }

--- a/src/operations/sti.rs
+++ b/src/operations/sti.rs
@@ -1,21 +1,15 @@
-use crate::{
-    VMState, error::VMError, mem_read, mem_write, operations::utils::sign_extend,
-    registers::Register,
-};
+use crate::{VMState, error::VMError, operations::utils::sign_extend, registers::Register};
 pub fn handle_sti(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let src_reg = ((instruction >> 9) & 0x7) as usize;
     let pc_offset = sign_extend(instruction & 0x1FF, 9);
-    let address = mem_read(
-        vm.registers[Register::PC.usize()].wrapping_add(pc_offset),
-        vm,
-    )?;
-    mem_write(address, vm.registers[src_reg], vm);
+    let address = vm.mem_read(vm.registers[Register::PC.usize()].wrapping_add(pc_offset))?;
+    vm.mem_write(address, vm.registers[src_reg]);
     Ok(())
 }
 
 #[cfg(test)]
 mod test {
-    use crate::{VMState, mem_read, mem_write, operations::sti::handle_sti, registers::Register};
+    use crate::{VMState, operations::sti::handle_sti, registers::Register};
 
     #[test]
     fn stores_reg_value_in_memory() {
@@ -28,19 +22,15 @@ mod test {
         // 1011 001         000001001
         let sti_ix = 0x0000;
         // Set the address that will be read.
-        mem_write(
-            default_pc_content.wrapping_add(pc_offset),
-            random_content,
-            &mut vm,
-        );
-        assert_eq!(mem_read(random_content, &mut vm).unwrap(), 0); // The memory in this address should have no content yet.
+        vm.mem_write(default_pc_content.wrapping_add(pc_offset), random_content);
+        assert_eq!(vm.mem_read(random_content).unwrap(), 0); // The memory in this address should have no content yet.
 
         let res = handle_sti(sti_ix, &mut vm);
         assert!(res.is_ok());
         // The memory address 0x1234 should have the same content as R1
         assert_eq!(
-            mem_read(random_content, &mut vm).unwrap(),
-            mem_read(vm.registers[Register::R1.usize()], &mut vm).unwrap()
+            vm.mem_read(random_content).unwrap(),
+            vm.mem_read(vm.registers[Register::R1.usize()]).unwrap()
         );
     }
 }

--- a/src/operations/str.rs
+++ b/src/operations/str.rs
@@ -1,12 +1,11 @@
-use crate::{VMState, error::VMError, mem_write, operations::utils::sign_extend};
+use crate::{VMState, error::VMError, operations::utils::sign_extend};
 pub fn handle_str(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let src_reg = ((instruction >> 9) & 0x7) as usize;
     let base_reg = ((instruction >> 6) & 0x7) as usize;
     let offset = sign_extend(instruction & 0x3F, 6);
-    mem_write(
+    vm.mem_write(
         vm.registers[base_reg].wrapping_add(offset),
         vm.registers[src_reg],
-        vm,
     );
     Ok(())
 }

--- a/src/operations/trap.rs
+++ b/src/operations/trap.rs
@@ -1,8 +1,4 @@
-use std::io::Read;
-
-use crate::{
-    VMState, error::VMError, mem_read, operations::utils::update_flags, registers::Register,
-};
+use crate::{error::VMError, operations::utils::update_flags, registers::Register, utils::get_char, VMState};
 pub fn handle_trap(instruction: u16, vm: &mut VMState, running: &mut bool) -> Result<(), VMError> {
     match TrapCode::try_from(instruction & 0xFF)? {
         TrapCode::Getc => handle_getc(vm)?,
@@ -51,13 +47,9 @@ impl TryFrom<u16> for TrapCode {
 }
 
 fn handle_getc(vm: &mut VMState) -> Result<(), VMError> {
-    let mut char = [0];
-    std::io::stdin()
-        .read_exact(&mut char)
-        .map_err(|e| VMError::CouldNotReadChar(e.to_string()))?;
-    vm.registers[Register::R0.usize()] = char[0] as u16;
-    update_flags(vm, vm.registers[Register::R0.usize()])?;
-
+    let char = get_char()?;
+    vm.registers[Register::R0.usize()] = char;
+    update_flags(vm, char)?;
     Ok(())
 }
 
@@ -69,7 +61,7 @@ fn handle_out(vm: &mut VMState) -> Result<(), VMError> {
 
 fn handle_putsp(vm: &mut VMState) -> Result<(), VMError> {
     let mut memory_address = vm.registers[Register::R0.usize()];
-    let mut content = mem_read(memory_address, vm)?;
+    let mut content = vm.mem_read(memory_address)?;
     while content != 0 {
         let bytes: [u8; 2] = content.to_le_bytes();
         print_char(bytes[0]);
@@ -77,29 +69,26 @@ fn handle_putsp(vm: &mut VMState) -> Result<(), VMError> {
             print_char(bytes[1]);
         }
         memory_address = memory_address.wrapping_add(1);
-        content = mem_read(memory_address, vm)?;
+        content = vm.mem_read(memory_address)?;
     }
     Ok(())
 }
 
 fn handle_in(vm: &mut VMState) -> Result<(), VMError> {
     print!("\n\rEnter a character: \n\r");
-    let mut char = [0];
-    std::io::stdin()
-        .read_exact(&mut char)
-        .map_err(|e| VMError::CouldNotReadChar(e.to_string()))?;
-    vm.registers[Register::R0.usize()] = char[0] as u16;
-    update_flags(vm, vm.registers[Register::R0.usize()])?;
+    let  char = get_char()?;
+    vm.registers[Register::R0.usize()] = char;
+    update_flags(vm, char)?;
     Ok(())
 }
 
 fn handle_puts(vm: &mut VMState) -> Result<(), VMError> {
     let mut memory_address = vm.registers[Register::R0.usize()];
-    let mut content = mem_read(memory_address, vm)?;
+    let mut content = vm.mem_read(memory_address)?;
     while content != 0 {
         print_char(content.to_le_bytes()[0]);
         memory_address = memory_address.wrapping_add(1);
-        content = mem_read(memory_address, vm)?;
+        content = vm.mem_read(memory_address)?;
     }
     Ok(())
 }

--- a/src/operations/trap.rs
+++ b/src/operations/trap.rs
@@ -1,4 +1,6 @@
-use crate::{error::VMError, operations::utils::update_flags, registers::Register, utils::get_char, VMState};
+use crate::{
+    VMState, error::VMError, operations::utils::update_flags, registers::Register, utils::get_char,
+};
 pub fn handle_trap(instruction: u16, vm: &mut VMState, running: &mut bool) -> Result<(), VMError> {
     match TrapCode::try_from(instruction & 0xFF)? {
         TrapCode::Getc => handle_getc(vm)?,
@@ -76,7 +78,7 @@ fn handle_putsp(vm: &mut VMState) -> Result<(), VMError> {
 
 fn handle_in(vm: &mut VMState) -> Result<(), VMError> {
     print!("\n\rEnter a character: \n\r");
-    let  char = get_char()?;
+    let char = get_char()?;
     vm.registers[Register::R0.usize()] = char;
     update_flags(vm, char)?;
     Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,39 @@
+use std::{fs, io::Read, os::fd::AsRawFd};
+
+use termios::{ECHO, ICANON, TCSANOW, Termios, tcsetattr};
+
+use crate::error::VMError;
+
+pub fn read_file(path: &str) -> Result<Vec<u8>, VMError> {
+    let read_result = fs::read(path).map_err(|e| VMError::CouldNotReadFile(e.to_string()))?;
+    Ok(read_result)
+}
+
+pub fn get_char() -> Result<u16, VMError> {
+    let mut buffer: [u8; 1] = [0];
+    std::io::stdin()
+        .read_exact(&mut buffer)
+        .map_err(|e| VMError::CouldNotReadChar(e.to_string()))?;
+    let char = buffer[0] as u16;
+
+    Ok(char)
+}
+
+pub fn disable_input_buffering() -> Result<(), VMError> {
+    let fd = std::io::stdin().lock().as_raw_fd();
+    let mut termios = Termios::from_fd(fd).map_err(|e| VMError::TermiosError(e.to_string()))?;
+    termios.c_lflag &= !ICANON & !ECHO;
+    tcsetattr(fd, TCSANOW, &termios).unwrap();
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn parse_file() {
+        let path = "./binary-examples/2048.obj";
+        let read_file = read_file(path).unwrap();
+        assert_eq!(read_file.len(), 2276);
+    }
+}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,0 +1,78 @@
+use crate::{
+    error::VMError,
+    flags::Flag,
+    registers::{MemoryRegister, Register},
+    utils::get_char,
+};
+
+pub const MEMORY_MAX: usize = 1 << 16;
+pub struct VMState {
+    pub memory: [u16; MEMORY_MAX],
+    pub registers: [u16; Register::COUNT],
+}
+impl VMState {
+    pub fn init() -> Result<Self, VMError> {
+        let mut vm = Self {
+            memory: [0; MEMORY_MAX],
+            registers: [0; Register::COUNT],
+        };
+        vm.registers[Register::Cond.usize()] = Flag::Zro.try_into()?;
+        vm.registers[Register::PC.usize()] = 0x3000; // Set PC to starting position. 0x3000 is the default.
+        Ok(vm)
+    }
+
+    pub fn write_ixs_to_mem(&mut self, parsed_file: Vec<u8>) {
+        let mut file_index = 0;
+        let origin = u16::from_be_bytes([parsed_file[file_index], parsed_file[file_index + 1]]);
+        file_index += 2;
+
+        let mut offset = origin;
+        while file_index + 1 < parsed_file.len() {
+            // LC3 binaries come in big endian but we need to store it swapped
+            let content =
+                u16::from_be_bytes([parsed_file[file_index], parsed_file[file_index + 1]]);
+            self.mem_write(offset, content);
+            file_index += 2;
+            offset += 1;
+        }
+    }
+
+    pub fn mem_write(&mut self, address: u16, val: u16) {
+        self.memory[address as usize] = val;
+    }
+
+    pub fn mem_read(&mut self, address: u16) -> Result<u16, VMError> {
+        if address == MemoryRegister::Kbsr.try_into()? {
+            let char = get_char()?;
+            if char != 0 {
+                self.memory[MemoryRegister::Kbsr.usize()] = 1 << 15;
+                self.memory[MemoryRegister::Kbdr.usize()] = char;
+            } else {
+                self.memory[MemoryRegister::Kbsr.usize()] = 0;
+            }
+        }
+        Ok(self.memory[address as usize])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn writes_ix_to_memory() {
+        let mut vm = VMState::init().unwrap();
+        let origin: u16 = 0x3000;
+        let first_ix: u16 = 0x4314;
+        let second_ix: u16 = 0x975A;
+        let binary = vec![
+            origin.to_be_bytes(),
+            first_ix.to_be_bytes(),
+            second_ix.to_be_bytes(),
+        ]
+        .concat();
+        vm.write_ixs_to_mem(binary);
+        assert_eq!(vm.memory[origin as usize], first_ix);
+        assert_eq!(vm.memory[(origin + 1) as usize], second_ix);
+    }
+}


### PR DESCRIPTION
This PR includes some restructuring of the VM. The major changes are: 
- Create a `utils.rs` file for functions `read_file`, `get_char` and `disable_input_buffering`. 
- Move the `VMState` to its own file and make functions `mem_read`, `mem_write` and `write_ixs_to_mem` part of its methods implementation.  
- Reuse the `get_char` util function in TRAP handles. 