### PR TITLE
Add missing update flags

### DIFF
--- a/src/operations/not.rs
+++ b/src/operations/not.rs
@@ -1,10 +1,10 @@
-use crate::{error::VMError, operations::utils::update_flags, VMState};
+use crate::{VMState, error::VMError, operations::utils::update_flags};
 
 pub fn handle_not(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let dest_reg = ((instruction >> 9) & 0x7) as usize;
     let src_reg = ((instruction >> 6) & 0x7) as usize;
     vm.registers[dest_reg] = !vm.registers[src_reg];
-    update_flags(vm, vm.registers[dest_reg])?; 
+    update_flags(vm, vm.registers[dest_reg])?;
     Ok(())
 }
 

--- a/src/operations/not.rs
+++ b/src/operations/not.rs
@@ -1,9 +1,10 @@
-use crate::{VMState, error::VMError};
+use crate::{error::VMError, operations::utils::update_flags, VMState};
 
 pub fn handle_not(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let dest_reg = ((instruction >> 9) & 0x7) as usize;
     let src_reg = ((instruction >> 6) & 0x7) as usize;
     vm.registers[dest_reg] = !vm.registers[src_reg];
+    update_flags(vm, vm.registers[dest_reg])?; 
     Ok(())
 }
 


### PR DESCRIPTION
Add missing call to `update_flags()` in NOT opcode handler. 