### PR TITLE
Restore terminal status

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use crate::operations::sti::handle_sti;
 use crate::operations::str::handle_str;
 use crate::operations::trap::handle_trap;
 use crate::registers::Register::*;
-use crate::utils::{disable_input_buffering, read_file};
+use crate::utils::{disable_input_buffering, read_file, restore_terminal};
 use crate::vm::VMState;
 
 fn main() -> Result<(), VMError> {
@@ -37,7 +37,7 @@ fn main() -> Result<(), VMError> {
     let path = console_args[1].clone();
     let file = read_file(&path)?;
 
-    disable_input_buffering()?;
+    let original_terminal_setup = disable_input_buffering()?;
     // Initialize VM state
     let mut vm = VMState::init()?;
 
@@ -74,5 +74,6 @@ fn main() -> Result<(), VMError> {
             .map_err(|e| VMError::ErrorFlushinStdout(e.to_string()))?;
     }
 
+    restore_terminal(original_terminal_setup)?;
     Ok(())
 }

--- a/src/operations/not.rs
+++ b/src/operations/not.rs
@@ -1,10 +1,10 @@
-use crate::{error::VMError, operations::utils::update_flags, VMState};
+use crate::{VMState, error::VMError, operations::utils::update_flags};
 
 pub fn handle_not(instruction: u16, vm: &mut VMState) -> Result<(), VMError> {
     let dest_reg = ((instruction >> 9) & 0x7) as usize;
     let src_reg = ((instruction >> 6) & 0x7) as usize;
     vm.registers[dest_reg] = !vm.registers[src_reg];
-    update_flags(vm, vm.registers[dest_reg])?; 
+    update_flags(vm, vm.registers[dest_reg])?;
     Ok(())
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,7 +30,7 @@ pub fn disable_input_buffering() -> Result<Termios, VMError> {
 
 pub fn restore_terminal(termios: Termios) -> Result<(), VMError> {
     let fd = std::io::stdin().lock().as_raw_fd();
-    tcsetattr(fd, TCSANOW, &termios).unwrap();
+    tcsetattr(fd, TCSANOW, &termios).map_err(|e| VMError::TermiosError(e.to_string()))?;
     Ok(())
 }
 


### PR DESCRIPTION
Add function `restore_terminal()` to set the terminal conditions to the original ones (input buffering and input echo) when the program finishes. 